### PR TITLE
fixes strata ordering and obs subsetting

### DIFF
--- a/R/get_controls.R
+++ b/R/get_controls.R
@@ -27,7 +27,6 @@ get_controls <- function(obs,
     # Matrix of locations
     xy <- as.matrix(sub_obs[, c("x", "y")])
     n_obs <- nrow(xy)
-    n_chars <- nchar(n_obs) # for padding with leading 0s
 
     # Get a few movement metrics
     steps <- sqrt(rowSums((xy[-1,] - xy[-n_obs,])^2))
@@ -51,7 +50,7 @@ get_controls <- function(obs,
         sim_step * cbind(cos(sim_bear), sin(sim_bear))
 
       data.frame(ID = id,
-                 stratum = factor(paste(id, formatC(i, width=nchars, flag = "0"), sep = "-")),
+                 stratum = factor(paste(id, formatC(i, width=nchar(n_obs), flag = "0"), sep = "-")),
                  obs = c(1, rep(0, n_controls)),
                  x = c(xy[i,1], pts[,1]),
                  y = c(xy[i,2], pts[,2]),

--- a/R/get_controls.R
+++ b/R/get_controls.R
@@ -27,6 +27,7 @@ get_controls <- function(obs,
     # Matrix of locations
     xy <- as.matrix(sub_obs[, c("x", "y")])
     n_obs <- nrow(xy)
+    n_chars <- nchar(n_obs) # for padding with leading 0s
 
     # Get a few movement metrics
     steps <- sqrt(rowSums((xy[-1,] - xy[-n_obs,])^2))
@@ -50,7 +51,7 @@ get_controls <- function(obs,
         sim_step * cbind(cos(sim_bear), sin(sim_bear))
 
       data.frame(ID = id,
-                 stratum = factor(paste(id, i, sep = "-")),
+                 stratum = factor(paste(id, formatC(i, width=nchars, flag = "0"), sep = "-")),
                  obs = c(1, rep(0, n_controls)),
                  x = c(xy[i,1], pts[,1]),
                  y = c(xy[i,2], pts[,2]),

--- a/R/nllk.R
+++ b/R/nllk.R
@@ -54,7 +54,7 @@ nllk <- function(par,
     v <- delta * densities[1,]
 
     # Loop over observations for this track
-    for(i in which(obs_ID == unique(ID[k]))) {
+    for(i in which(obs_ID == unique(ID)[k])) {
       v <- v %*% Gamma[,,i] * densities[i,]
       llk <- llk + log(sum(v))
       v <- v/sum(v)


### PR DESCRIPTION
Minor fixes on what I believe are unintended bugs.

function `hmmSSF()` orders data according to
```r
data <- data[order(data$ID, data$stratum, -data$obs), ]
```

however, `get_controls()` returns strata as a factor formatted as "ID-step" where step is an integer number. As the levels are arranged by alphabetical order, the data sorting will be off: steps 10, 100, etc. will come before step 2; steps 20, 200 etc. will come before step 3; and so on. My tentative solution is to format the step as a character and padding it with leading 0s. Now the factor orders the levels correctly and the data will be ordered accordingly by `hmmSSF()`.

Additionally, I believe line 57 of the `nllk()` function was intended to subset observations according to `unique(ID)[k]` rather than `unique(ID[k])` (i.e. index in square brackets outside, not inside)