### PR TITLE
another minor fix to forward algorithm

### DIFF
--- a/R/nllk.R
+++ b/R/nllk.R
@@ -54,7 +54,7 @@ nllk <- function(par,
     ind <- which(obs_ID == unique_ID[k])
 
     # get initial density for this track
-    v <- delta * densities[1,]
+    v <- delta * densities[ind[1],]
 
     # Loop over observations for this track
     for(i in ind[-length(ind)]) {


### PR DESCRIPTION
Hello, me again.

I noticed that the initial P(X) for each track was drawn always from the first element of the density vector in the loop. I believe it was intended to be subset by ind[1] instead.